### PR TITLE
Fix response on peer not registered

### DIFF
--- a/dispatcher/dispatcher.go
+++ b/dispatcher/dispatcher.go
@@ -42,6 +42,7 @@ func (d *Dispatcher) SendMessage(ctx context.Context, msg *proto.EncryptedMessag
 	d.mu.RUnlock()
 
 	if !ok {
+		log.Tracef("message from peer [%s] can't be forwarded to peer [%s] because destination peer is not connected", msg.Key, msg.RemoteKey)
 		return &proto.EncryptedMessage{}, nil
 	}
 

--- a/dispatcher/dispatcher.go
+++ b/dispatcher/dispatcher.go
@@ -3,7 +3,6 @@ package dispatcher
 import (
 	"context"
 	"errors"
-	"fmt"
 	"sync"
 
 	log "github.com/sirupsen/logrus"
@@ -43,7 +42,7 @@ func (d *Dispatcher) SendMessage(ctx context.Context, msg *proto.EncryptedMessag
 	d.mu.RUnlock()
 
 	if !ok {
-		return nil, fmt.Errorf("peer %s not connected", msg.RemoteKey)
+		return &proto.EncryptedMessage{}, nil
 	}
 
 	select {


### PR DESCRIPTION
We need to send an empty response instead of an error if the peer is not registered